### PR TITLE
fix: align payload v3 types and config

### DIFF
--- a/backend/src/collections/Locations.ts
+++ b/backend/src/collections/Locations.ts
@@ -1,4 +1,4 @@
-import { CollectionConfig } from 'payload';
+import type { CollectionConfig, PayloadRequest } from 'payload'
 
 const Locations: CollectionConfig = {
   slug: 'locations',
@@ -8,9 +8,11 @@ const Locations: CollectionConfig = {
   },
   access: {
     read: () => true,
-    create: ({ req: { user } }) => user?.role === 'editor' || user?.role === 'admin',
-    update: ({ req: { user } }) => user?.role === 'editor' || user?.role === 'admin',
-    delete: ({ req: { user } }) => user?.role === 'admin',
+    create: ({ req }: { req: PayloadRequest }) =>
+      req.user?.role === 'editor' || req.user?.role === 'admin',
+    update: ({ req }: { req: PayloadRequest }) =>
+      req.user?.role === 'editor' || req.user?.role === 'admin',
+    delete: ({ req }: { req: PayloadRequest }) => req.user?.role === 'admin',
   },
   fields: [
     {
@@ -76,6 +78,6 @@ const Locations: CollectionConfig = {
     },
   ],
   timestamps: true,
-};
+}
 
-export default Locations;
+export default Locations

--- a/backend/src/collections/Media.ts
+++ b/backend/src/collections/Media.ts
@@ -1,10 +1,9 @@
-import { CollectionConfig } from 'payload';
+import type { CollectionConfig } from 'payload'
 
 const Media: CollectionConfig = {
   slug: 'media',
   upload: {
     staticDir: '../uploads',
-    staticURL: '/uploads',
     mimeTypes: ['image/*'],
     imageSizes: [
       {
@@ -35,6 +34,6 @@ const Media: CollectionConfig = {
       label: 'Alt Text',
     },
   ],
-};
+}
 
-export default Media;
+export default Media

--- a/backend/src/collections/Organizations.ts
+++ b/backend/src/collections/Organizations.ts
@@ -1,4 +1,4 @@
-import { CollectionConfig } from 'payload';
+import type { CollectionConfig, PayloadRequest } from 'payload'
 
 const Organizations: CollectionConfig = {
   slug: 'organizations',
@@ -10,13 +10,14 @@ const Organizations: CollectionConfig = {
   access: {
     read: () => true,
     create: () => true,
-    update: ({ req: { user } }) => {
-      if (user?.role === 'admin') return true;
+    update: ({ req }: { req: PayloadRequest }) => {
+      const { user } = req
+      if (user?.role === 'admin') return true
       return {
         id: {
           equals: user?.id,
         },
-      };
+      } as any
     },
   },
   fields: [
@@ -36,7 +37,7 @@ const Organizations: CollectionConfig = {
       ],
       defaultValue: 'organizer',
       access: {
-        update: ({ req: { user } }) => user?.role === 'admin',
+        update: ({ req }: { req: PayloadRequest }) => req.user?.role === 'admin',
       },
     },
     {
@@ -77,11 +78,12 @@ const Organizations: CollectionConfig = {
       label: 'Freigegeben',
       defaultValue: false,
       access: {
-        update: ({ req: { user } }) => user?.role === 'editor' || user?.role === 'admin',
+        update: ({ req }: { req: PayloadRequest }) =>
+          req.user?.role === 'editor' || req.user?.role === 'admin',
       },
     },
   ],
   timestamps: true,
-};
+}
 
-export default Organizations;
+export default Organizations

--- a/backend/src/collections/Tags.ts
+++ b/backend/src/collections/Tags.ts
@@ -1,4 +1,4 @@
-import { CollectionConfig } from 'payload';
+import type { CollectionConfig, PayloadRequest } from 'payload'
 
 const Tags: CollectionConfig = {
   slug: 'tags',
@@ -7,9 +7,11 @@ const Tags: CollectionConfig = {
   },
   access: {
     read: () => true,
-    create: ({ req: { user } }) => user?.role === 'editor' || user?.role === 'admin',
-    update: ({ req: { user } }) => user?.role === 'editor' || user?.role === 'admin',
-    delete: ({ req: { user } }) => user?.role === 'admin',
+    create: ({ req }: { req: PayloadRequest }) =>
+      req.user?.role === 'editor' || req.user?.role === 'admin',
+    update: ({ req }: { req: PayloadRequest }) =>
+      req.user?.role === 'editor' || req.user?.role === 'admin',
+    delete: ({ req }: { req: PayloadRequest }) => req.user?.role === 'admin',
   },
   fields: [
     {
@@ -47,6 +49,6 @@ const Tags: CollectionConfig = {
       },
     },
   ],
-};
+}
 
-export default Tags;
+export default Tags

--- a/backend/src/payload-types.ts
+++ b/backend/src/payload-types.ts
@@ -59,240 +59,509 @@ export type SupportedTimezones =
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
-  | 'Pacific/Fiji';
+  | 'Pacific/Fiji'
 
 export interface Config {
   auth: {
-    users: UserAuthOperations;
-  };
-  blocks: {};
+    organizations: OrganizationAuthOperations
+  }
+  blocks: {}
   collections: {
-    users: User;
-    media: Media;
-    'payload-locked-documents': PayloadLockedDocument;
-    'payload-preferences': PayloadPreference;
-    'payload-migrations': PayloadMigration;
-  };
-  collectionsJoins: {};
+    organizations: Organization
+    events: Event
+    locations: Location
+    tags: Tag
+    media: Media
+    'payload-locked-documents': PayloadLockedDocument
+    'payload-preferences': PayloadPreference
+    'payload-migrations': PayloadMigration
+  }
+  collectionsJoins: {}
   collectionsSelect: {
-    users: UsersSelect<false> | UsersSelect<true>;
-    media: MediaSelect<false> | MediaSelect<true>;
-    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
-    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
-    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
-  };
+    organizations: OrganizationsSelect<false> | OrganizationsSelect<true>
+    events: EventsSelect<false> | EventsSelect<true>
+    locations: LocationsSelect<false> | LocationsSelect<true>
+    tags: TagsSelect<false> | TagsSelect<true>
+    media: MediaSelect<false> | MediaSelect<true>
+    'payload-locked-documents':
+      | PayloadLockedDocumentsSelect<false>
+      | PayloadLockedDocumentsSelect<true>
+    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>
+    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>
+  }
   db: {
-    defaultIDType: string;
-  };
-  globals: {};
-  globalsSelect: {};
-  locale: null;
-  user: User & {
-    collection: 'users';
-  };
+    defaultIDType: string
+  }
+  globals: {}
+  globalsSelect: {}
+  locale: null
+  user: Organization & {
+    collection: 'organizations'
+  }
   jobs: {
-    tasks: unknown;
-    workflows: unknown;
-  };
+    tasks: unknown
+    workflows: unknown
+  }
 }
-export interface UserAuthOperations {
+export interface OrganizationAuthOperations {
   forgotPassword: {
-    email: string;
-    password: string;
-  };
+    email: string
+    password: string
+  }
   login: {
-    email: string;
-    password: string;
-  };
+    email: string
+    password: string
+  }
   registerFirstUser: {
-    email: string;
-    password: string;
-  };
+    email: string
+    password: string
+  }
   unlock: {
-    email: string;
-    password: string;
-  };
+    email: string
+    password: string
+  }
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users".
+ * via the `definition` "organizations".
  */
-export interface User {
-  id: string;
-  updatedAt: string;
-  createdAt: string;
-  email: string;
-  resetPasswordToken?: string | null;
-  resetPasswordExpiration?: string | null;
-  salt?: string | null;
-  hash?: string | null;
-  loginAttempts?: number | null;
-  lockUntil?: string | null;
+export interface Organization {
+  id: string
+  name: string
+  role?: ('organizer' | 'editor' | 'admin') | null
+  contactPerson?: string | null
+  address?: {
+    street?: string | null
+    number?: string | null
+    postalCode?: string | null
+    city?: string | null
+  }
+  website?: string | null
+  phone?: string | null
+  logo?: (string | null) | Media
+  approved?: boolean | null
+  updatedAt: string
+  createdAt: string
+  email: string
+  resetPasswordToken?: string | null
+  resetPasswordExpiration?: string | null
+  salt?: string | null
+  hash?: string | null
+  loginAttempts?: number | null
+  lockUntil?: string | null
   sessions?:
     | {
-        id: string;
-        createdAt?: string | null;
-        expiresAt: string;
+        id: string
+        createdAt?: string | null
+        expiresAt: string
       }[]
-    | null;
-  password?: string | null;
+    | null
+  password?: string | null
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
-  id: string;
-  alt: string;
-  updatedAt: string;
-  createdAt: string;
-  url?: string | null;
-  thumbnailURL?: string | null;
-  filename?: string | null;
-  mimeType?: string | null;
-  filesize?: number | null;
-  width?: number | null;
-  height?: number | null;
-  focalX?: number | null;
-  focalY?: number | null;
+  id: string
+  alt: string
+  updatedAt: string
+  createdAt: string
+  url?: string | null
+  thumbnailURL?: string | null
+  filename?: string | null
+  mimeType?: string | null
+  filesize?: number | null
+  width?: number | null
+  height?: number | null
+  focalX?: number | null
+  focalY?: number | null
+  sizes?: {
+    thumbnail?: {
+      url?: string | null
+      width?: number | null
+      height?: number | null
+      mimeType?: string | null
+      filesize?: number | null
+      filename?: string | null
+    }
+    card?: {
+      url?: string | null
+      width?: number | null
+      height?: number | null
+      mimeType?: string | null
+      filesize?: number | null
+      filename?: string | null
+    }
+    tablet?: {
+      url?: string | null
+      width?: number | null
+      height?: number | null
+      mimeType?: string | null
+      filesize?: number | null
+      filename?: string | null
+    }
+  }
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events".
+ */
+export interface Event {
+  id: string
+  title: string
+  subtitle?: string | null
+  eventType: 'einmalig' | 'täglich' | 'wöchentlich' | 'monatlich' | 'jährlich'
+  startDate: string
+  endDate?: string | null
+  time?: {
+    from?: string | null
+    to?: string | null
+  }
+  description: string
+  image?: (string | null) | Media
+  location: string | Location
+  organizer: string | Organization
+  isAccessible?: boolean | null
+  cost?: {
+    isFree?: boolean | null
+    details?: string | null
+  }
+  registration?: {
+    required?: boolean | null
+    details?: string | null
+  }
+  tags?: (string | Tag)[] | null
+  status: 'draft' | 'pending' | 'approved' | 'archived'
+  updatedAt: string
+  createdAt: string
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "locations".
+ */
+export interface Location {
+  id: string
+  name: string
+  /**
+   * Erscheint im Filtermenü und in der Karte
+   */
+  shortName: string
+  description?: string | null
+  image?: (string | null) | Media
+  address: {
+    street: string
+    number: string
+    postalCode: string
+    city?: string | null
+  }
+  /**
+   * @minItems 2
+   * @maxItems 2
+   */
+  coordinates?: [number, number] | null
+  /**
+   * X und Y Position in Prozent (0-100)
+   */
+  mapPosition?: {
+    x?: number | null
+    y?: number | null
+  }
+  openingHours?: string | null
+  updatedAt: string
+  createdAt: string
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
+export interface Tag {
+  id: string
+  name: string
+  slug: string
+  category?: ('target' | 'topic' | 'format') | null
+  /**
+   * z.B. #7CB92C
+   */
+  color?: string | null
+  updatedAt: string
+  createdAt: string
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string;
+  id: string
   document?:
     | ({
-        relationTo: 'users';
-        value: string | User;
+        relationTo: 'organizations'
+        value: string | Organization
       } | null)
     | ({
-        relationTo: 'media';
-        value: string | Media;
-      } | null);
-  globalSlug?: string | null;
+        relationTo: 'events'
+        value: string | Event
+      } | null)
+    | ({
+        relationTo: 'locations'
+        value: string | Location
+      } | null)
+    | ({
+        relationTo: 'tags'
+        value: string | Tag
+      } | null)
+    | ({
+        relationTo: 'media'
+        value: string | Media
+      } | null)
+  globalSlug?: string | null
   user: {
-    relationTo: 'users';
-    value: string | User;
-  };
-  updatedAt: string;
-  createdAt: string;
+    relationTo: 'organizations'
+    value: string | Organization
+  }
+  updatedAt: string
+  createdAt: string
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string;
+  id: string
   user: {
-    relationTo: 'users';
-    value: string | User;
-  };
-  key?: string | null;
+    relationTo: 'organizations'
+    value: string | Organization
+  }
+  key?: string | null
   value?:
     | {
-        [k: string]: unknown;
+        [k: string]: unknown
       }
     | unknown[]
     | string
     | number
     | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
+    | null
+  updatedAt: string
+  createdAt: string
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string;
-  name?: string | null;
-  batch?: number | null;
-  updatedAt: string;
-  createdAt: string;
+  id: string
+  name?: string | null
+  batch?: number | null
+  updatedAt: string
+  createdAt: string
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "users_select".
+ * via the `definition` "organizations_select".
  */
-export interface UsersSelect<T extends boolean = true> {
-  updatedAt?: T;
-  createdAt?: T;
-  email?: T;
-  resetPasswordToken?: T;
-  resetPasswordExpiration?: T;
-  salt?: T;
-  hash?: T;
-  loginAttempts?: T;
-  lockUntil?: T;
+export interface OrganizationsSelect<T extends boolean = true> {
+  name?: T
+  role?: T
+  contactPerson?: T
+  address?:
+    | T
+    | {
+        street?: T
+        number?: T
+        postalCode?: T
+        city?: T
+      }
+  website?: T
+  phone?: T
+  logo?: T
+  approved?: T
+  updatedAt?: T
+  createdAt?: T
+  email?: T
+  resetPasswordToken?: T
+  resetPasswordExpiration?: T
+  salt?: T
+  hash?: T
+  loginAttempts?: T
+  lockUntil?: T
   sessions?:
     | T
     | {
-        id?: T;
-        createdAt?: T;
-        expiresAt?: T;
-      };
+        id?: T
+        createdAt?: T
+        expiresAt?: T
+      }
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events_select".
+ */
+export interface EventsSelect<T extends boolean = true> {
+  title?: T
+  subtitle?: T
+  eventType?: T
+  startDate?: T
+  endDate?: T
+  time?:
+    | T
+    | {
+        from?: T
+        to?: T
+      }
+  description?: T
+  image?: T
+  location?: T
+  organizer?: T
+  isAccessible?: T
+  cost?:
+    | T
+    | {
+        isFree?: T
+        details?: T
+      }
+  registration?:
+    | T
+    | {
+        required?: T
+        details?: T
+      }
+  tags?: T
+  status?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "locations_select".
+ */
+export interface LocationsSelect<T extends boolean = true> {
+  name?: T
+  shortName?: T
+  description?: T
+  image?: T
+  address?:
+    | T
+    | {
+        street?: T
+        number?: T
+        postalCode?: T
+        city?: T
+      }
+  coordinates?: T
+  mapPosition?:
+    | T
+    | {
+        x?: T
+        y?: T
+      }
+  openingHours?: T
+  updatedAt?: T
+  createdAt?: T
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags_select".
+ */
+export interface TagsSelect<T extends boolean = true> {
+  name?: T
+  slug?: T
+  category?: T
+  color?: T
+  updatedAt?: T
+  createdAt?: T
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
-  alt?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  url?: T;
-  thumbnailURL?: T;
-  filename?: T;
-  mimeType?: T;
-  filesize?: T;
-  width?: T;
-  height?: T;
-  focalX?: T;
-  focalY?: T;
+  alt?: T
+  updatedAt?: T
+  createdAt?: T
+  url?: T
+  thumbnailURL?: T
+  filename?: T
+  mimeType?: T
+  filesize?: T
+  width?: T
+  height?: T
+  focalX?: T
+  focalY?: T
+  sizes?:
+    | T
+    | {
+        thumbnail?:
+          | T
+          | {
+              url?: T
+              width?: T
+              height?: T
+              mimeType?: T
+              filesize?: T
+              filename?: T
+            }
+        card?:
+          | T
+          | {
+              url?: T
+              width?: T
+              height?: T
+              mimeType?: T
+              filesize?: T
+              filename?: T
+            }
+        tablet?:
+          | T
+          | {
+              url?: T
+              width?: T
+              height?: T
+              mimeType?: T
+              filesize?: T
+              filename?: T
+            }
+      }
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents_select".
  */
 export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
-  document?: T;
-  globalSlug?: T;
-  user?: T;
-  updatedAt?: T;
-  createdAt?: T;
+  document?: T
+  globalSlug?: T
+  user?: T
+  updatedAt?: T
+  createdAt?: T
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences_select".
  */
 export interface PayloadPreferencesSelect<T extends boolean = true> {
-  user?: T;
-  key?: T;
-  value?: T;
-  updatedAt?: T;
-  createdAt?: T;
+  user?: T
+  key?: T
+  value?: T
+  updatedAt?: T
+  createdAt?: T
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-migrations_select".
  */
 export interface PayloadMigrationsSelect<T extends boolean = true> {
-  name?: T;
-  batch?: T;
-  updatedAt?: T;
-  createdAt?: T;
+  name?: T
+  batch?: T
+  updatedAt?: T
+  createdAt?: T
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {
-  [k: string]: unknown;
+  [k: string]: unknown
 }
-
 
 declare module 'payload' {
   export interface GeneratedTypes extends Config {}

--- a/backend/src/payload.config.ts
+++ b/backend/src/payload.config.ts
@@ -1,16 +1,19 @@
-import { buildConfig } from 'payload';
-import path from 'path';
-import Organizations from './collections/Organizations';
-import Events from './collections/Events';
-import Locations from './collections/Locations';
-import Tags from './collections/Tags';
-import Media from './collections/Media';
-import 'dotenv/config'; // make sure env vars are available
-import { mongooseAdapter } from '@payloadcms/db-mongodb';
+import { buildConfig } from 'payload'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import Organizations from './collections/Organizations'
+import Events from './collections/Events'
+import Locations from './collections/Locations'
+import Tags from './collections/Tags'
+import Media from './collections/Media'
+import 'dotenv/config' // make sure env vars are available
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default buildConfig({
   secret: process.env.PAYLOAD_SECRET as string,
-    db: mongooseAdapter({
+  db: mongooseAdapter({
     url: process.env.DATABASE_URI as string,
   }),
   serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL || 'http://localhost:3000',
@@ -18,19 +21,12 @@ export default buildConfig({
     user: Organizations.slug,
     meta: {
       titleSuffix: '- MoaFinder CMS',
-      favicon: '/favicon.ico',
     },
   },
-  collections: [
-    Organizations,
-    Events,
-    Locations,
-    Tags,
-    Media,
-  ],
+  collections: [Organizations, Events, Locations, Tags, Media],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },
   cors: process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [],
   csrf: process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [],
-});
+})

--- a/backend/tests/int/api.int.spec.ts
+++ b/backend/tests/int/api.int.spec.ts
@@ -11,10 +11,10 @@ describe('API', () => {
     payload = await getPayload({ config: payloadConfig })
   })
 
-  it('fetches users', async () => {
-    const users = await payload.find({
-      collection: 'users',
+  it('fetches organizations', async () => {
+    const organizations = await payload.find({
+      collection: 'organizations',
     })
-    expect(users).toBeDefined()
+    expect(organizations).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- adjust collection access functions to use PayloadRequest user info
- remove deprecated staticURL and favicon config entries
- regenerate payload types and update integration test to organizations

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm run lint` *(fails: request defined but unused, no-explicit-any warnings)*
- `pnpm run test:int` *(fails: missing secret key)*
- `pnpm run test:e2e` *(fails: Node option not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689df0ff80a48326ab6effa785cd3ea7