### PR TITLE
feat(auth): add login flow and notes

### DIFF
--- a/backend/src/collections/Notes.ts
+++ b/backend/src/collections/Notes.ts
@@ -1,0 +1,43 @@
+import type { CollectionConfig, PayloadRequest } from 'payload'
+
+const Notes: CollectionConfig = {
+  slug: 'notes',
+  access: {
+    read: ({ req }: { req: PayloadRequest }) => {
+      if (!req.user) return false
+      return { user: { equals: req.user.id } } as any
+    },
+    create: ({ req }: { req: PayloadRequest }) => !!req.user,
+    update: ({ req }: { req: PayloadRequest }) => {
+      if (!req.user) return false
+      return { user: { equals: req.user.id } } as any
+    },
+    delete: ({ req }: { req: PayloadRequest }) => {
+      if (!req.user) return false
+      return { user: { equals: req.user.id } } as any
+    },
+  },
+  fields: [
+    {
+      name: 'content',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      defaultValue: ({ user }: { user: PayloadRequest['user'] }) => user?.id,
+      access: {
+        update: ({ req }: { req: PayloadRequest }) => req.user?.role === 'admin',
+      },
+      admin: {
+        readOnly: true,
+      },
+    },
+  ],
+  timestamps: true,
+}
+
+export default Notes

--- a/backend/src/collections/Users.ts
+++ b/backend/src/collections/Users.ts
@@ -7,7 +7,28 @@ export const Users: CollectionConfig = {
   },
   auth: true,
   fields: [
-    // Email added by default
-    // Add more fields as needed
+    {
+      name: 'role',
+      type: 'select',
+      required: true,
+      defaultValue: 'organizer',
+      options: [
+        {
+          label: 'Admin',
+          value: 'admin',
+        },
+        {
+          label: 'Editor',
+          value: 'editor',
+        },
+        {
+          label: 'Organizer',
+          value: 'organizer',
+        },
+      ],
+      access: {
+        update: ({ req }) => req.user?.role === 'admin',
+      },
+    },
   ],
 }

--- a/backend/src/payload-types.ts
+++ b/backend/src/payload-types.ts
@@ -59,509 +59,626 @@ export type SupportedTimezones =
   | 'Pacific/Guam'
   | 'Pacific/Noumea'
   | 'Pacific/Auckland'
-  | 'Pacific/Fiji'
+  | 'Pacific/Fiji';
 
 export interface Config {
   auth: {
-    organizations: OrganizationAuthOperations
-  }
-  blocks: {}
+    users: UserAuthOperations;
+    organizations: OrganizationAuthOperations;
+  };
+  blocks: {};
   collections: {
-    organizations: Organization
-    events: Event
-    locations: Location
-    tags: Tag
-    media: Media
-    'payload-locked-documents': PayloadLockedDocument
-    'payload-preferences': PayloadPreference
-    'payload-migrations': PayloadMigration
-  }
-  collectionsJoins: {}
+    users: User;
+    organizations: Organization;
+    events: Event;
+    locations: Location;
+    tags: Tag;
+    media: Media;
+    notes: Note;
+    'payload-locked-documents': PayloadLockedDocument;
+    'payload-preferences': PayloadPreference;
+    'payload-migrations': PayloadMigration;
+  };
+  collectionsJoins: {};
   collectionsSelect: {
-    organizations: OrganizationsSelect<false> | OrganizationsSelect<true>
-    events: EventsSelect<false> | EventsSelect<true>
-    locations: LocationsSelect<false> | LocationsSelect<true>
-    tags: TagsSelect<false> | TagsSelect<true>
-    media: MediaSelect<false> | MediaSelect<true>
-    'payload-locked-documents':
-      | PayloadLockedDocumentsSelect<false>
-      | PayloadLockedDocumentsSelect<true>
-    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>
-    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>
-  }
+    users: UsersSelect<false> | UsersSelect<true>;
+    organizations: OrganizationsSelect<false> | OrganizationsSelect<true>;
+    events: EventsSelect<false> | EventsSelect<true>;
+    locations: LocationsSelect<false> | LocationsSelect<true>;
+    tags: TagsSelect<false> | TagsSelect<true>;
+    media: MediaSelect<false> | MediaSelect<true>;
+    notes: NotesSelect<false> | NotesSelect<true>;
+    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
+    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
+    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
+  };
   db: {
-    defaultIDType: string
-  }
-  globals: {}
-  globalsSelect: {}
-  locale: null
-  user: Organization & {
-    collection: 'organizations'
-  }
+    defaultIDType: string;
+  };
+  globals: {};
+  globalsSelect: {};
+  locale: null;
+  user:
+    | (User & {
+        collection: 'users';
+      })
+    | (Organization & {
+        collection: 'organizations';
+      });
   jobs: {
-    tasks: unknown
-    workflows: unknown
-  }
+    tasks: unknown;
+    workflows: unknown;
+  };
+}
+export interface UserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
 }
 export interface OrganizationAuthOperations {
   forgotPassword: {
-    email: string
-    password: string
-  }
+    email: string;
+    password: string;
+  };
   login: {
-    email: string
-    password: string
-  }
+    email: string;
+    password: string;
+  };
   registerFirstUser: {
-    email: string
-    password: string
-  }
+    email: string;
+    password: string;
+  };
   unlock: {
-    email: string
-    password: string
-  }
+    email: string;
+    password: string;
+  };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users".
+ */
+export interface User {
+  id: string;
+  role: 'admin' | 'editor' | 'organizer';
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
+  sessions?:
+    | {
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
+      }[]
+    | null;
+  password?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "organizations".
  */
 export interface Organization {
-  id: string
-  name: string
-  role?: ('organizer' | 'editor' | 'admin') | null
-  contactPerson?: string | null
+  id: string;
+  name: string;
+  role?: ('organizer' | 'editor' | 'admin') | null;
+  contactPerson?: string | null;
   address?: {
-    street?: string | null
-    number?: string | null
-    postalCode?: string | null
-    city?: string | null
-  }
-  website?: string | null
-  phone?: string | null
-  logo?: (string | null) | Media
-  approved?: boolean | null
-  updatedAt: string
-  createdAt: string
-  email: string
-  resetPasswordToken?: string | null
-  resetPasswordExpiration?: string | null
-  salt?: string | null
-  hash?: string | null
-  loginAttempts?: number | null
-  lockUntil?: string | null
+    street?: string | null;
+    number?: string | null;
+    postalCode?: string | null;
+    city?: string | null;
+  };
+  website?: string | null;
+  phone?: string | null;
+  logo?: (string | null) | Media;
+  approved?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  email: string;
+  resetPasswordToken?: string | null;
+  resetPasswordExpiration?: string | null;
+  salt?: string | null;
+  hash?: string | null;
+  loginAttempts?: number | null;
+  lockUntil?: string | null;
   sessions?:
     | {
-        id: string
-        createdAt?: string | null
-        expiresAt: string
+        id: string;
+        createdAt?: string | null;
+        expiresAt: string;
       }[]
-    | null
-  password?: string | null
+    | null;
+  password?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
-  id: string
-  alt: string
-  updatedAt: string
-  createdAt: string
-  url?: string | null
-  thumbnailURL?: string | null
-  filename?: string | null
-  mimeType?: string | null
-  filesize?: number | null
-  width?: number | null
-  height?: number | null
-  focalX?: number | null
-  focalY?: number | null
+  id: string;
+  alt: string;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
   sizes?: {
     thumbnail?: {
-      url?: string | null
-      width?: number | null
-      height?: number | null
-      mimeType?: string | null
-      filesize?: number | null
-      filename?: string | null
-    }
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
     card?: {
-      url?: string | null
-      width?: number | null
-      height?: number | null
-      mimeType?: string | null
-      filesize?: number | null
-      filename?: string | null
-    }
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
     tablet?: {
-      url?: string | null
-      width?: number | null
-      height?: number | null
-      mimeType?: string | null
-      filesize?: number | null
-      filename?: string | null
-    }
-  }
+      url?: string | null;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: string | null;
+      filesize?: number | null;
+      filename?: string | null;
+    };
+  };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "events".
  */
 export interface Event {
-  id: string
-  title: string
-  subtitle?: string | null
-  eventType: 'einmalig' | 'täglich' | 'wöchentlich' | 'monatlich' | 'jährlich'
-  startDate: string
-  endDate?: string | null
+  id: string;
+  title: string;
+  subtitle?: string | null;
+  eventType: 'einmalig' | 'täglich' | 'wöchentlich' | 'monatlich' | 'jährlich';
+  startDate: string;
+  endDate?: string | null;
   time?: {
-    from?: string | null
-    to?: string | null
-  }
-  description: string
-  image?: (string | null) | Media
-  location: string | Location
-  organizer: string | Organization
-  isAccessible?: boolean | null
+    from?: string | null;
+    to?: string | null;
+  };
+  description: string;
+  image?: (string | null) | Media;
+  location: string | Location;
+  organizer: string | Organization;
+  isAccessible?: boolean | null;
   cost?: {
-    isFree?: boolean | null
-    details?: string | null
-  }
+    isFree?: boolean | null;
+    details?: string | null;
+  };
   registration?: {
-    required?: boolean | null
-    details?: string | null
-  }
-  tags?: (string | Tag)[] | null
-  status: 'draft' | 'pending' | 'approved' | 'archived'
-  updatedAt: string
-  createdAt: string
+    required?: boolean | null;
+    details?: string | null;
+  };
+  tags?: (string | Tag)[] | null;
+  status: 'draft' | 'pending' | 'approved' | 'archived';
+  expiryDate?: string | null;
+  lastRenewalReminder?: string | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "locations".
  */
 export interface Location {
-  id: string
-  name: string
+  id: string;
+  name: string;
   /**
    * Erscheint im Filtermenü und in der Karte
    */
-  shortName: string
-  description?: string | null
-  image?: (string | null) | Media
+  shortName: string;
+  description?: string | null;
+  image?: (string | null) | Media;
   address: {
-    street: string
-    number: string
-    postalCode: string
-    city?: string | null
-  }
+    street: string;
+    number: string;
+    postalCode: string;
+    city?: string | null;
+  };
   /**
    * @minItems 2
    * @maxItems 2
    */
-  coordinates?: [number, number] | null
+  coordinates?: [number, number] | null;
   /**
    * X und Y Position in Prozent (0-100)
    */
   mapPosition?: {
-    x?: number | null
-    y?: number | null
-  }
-  openingHours?: string | null
-  updatedAt: string
-  createdAt: string
+    x?: number | null;
+    y?: number | null;
+  };
+  openingHours?: string | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "tags".
  */
 export interface Tag {
-  id: string
-  name: string
-  slug: string
-  category?: ('target' | 'topic' | 'format') | null
+  id: string;
+  name: string;
+  slug: string;
+  category?: ('target' | 'topic' | 'format') | null;
   /**
    * z.B. #7CB92C
    */
-  color?: string | null
-  updatedAt: string
-  createdAt: string
+  color?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "notes".
+ */
+export interface Note {
+  id: string;
+  content: string;
+  user: string | User;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: string
+  id: string;
   document?:
     | ({
-        relationTo: 'organizations'
-        value: string | Organization
+        relationTo: 'users';
+        value: string | User;
       } | null)
     | ({
-        relationTo: 'events'
-        value: string | Event
+        relationTo: 'organizations';
+        value: string | Organization;
       } | null)
     | ({
-        relationTo: 'locations'
-        value: string | Location
+        relationTo: 'events';
+        value: string | Event;
       } | null)
     | ({
-        relationTo: 'tags'
-        value: string | Tag
+        relationTo: 'locations';
+        value: string | Location;
       } | null)
     | ({
-        relationTo: 'media'
-        value: string | Media
+        relationTo: 'tags';
+        value: string | Tag;
       } | null)
-  globalSlug?: string | null
-  user: {
-    relationTo: 'organizations'
-    value: string | Organization
-  }
-  updatedAt: string
-  createdAt: string
+    | ({
+        relationTo: 'media';
+        value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'notes';
+        value: string | Note;
+      } | null);
+  globalSlug?: string | null;
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'organizations';
+        value: string | Organization;
+      };
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: string
-  user: {
-    relationTo: 'organizations'
-    value: string | Organization
-  }
-  key?: string | null
+  id: string;
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'organizations';
+        value: string | Organization;
+      };
+  key?: string | null;
   value?:
     | {
-        [k: string]: unknown
+        [k: string]: unknown;
       }
     | unknown[]
     | string
     | number
     | boolean
-    | null
-  updatedAt: string
-  createdAt: string
+    | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: string
-  name?: string | null
-  batch?: number | null
-  updatedAt: string
-  createdAt: string
+  id: string;
+  name?: string | null;
+  batch?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "users_select".
+ */
+export interface UsersSelect<T extends boolean = true> {
+  role?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
+  sessions?:
+    | T
+    | {
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "organizations_select".
  */
 export interface OrganizationsSelect<T extends boolean = true> {
-  name?: T
-  role?: T
-  contactPerson?: T
+  name?: T;
+  role?: T;
+  contactPerson?: T;
   address?:
     | T
     | {
-        street?: T
-        number?: T
-        postalCode?: T
-        city?: T
-      }
-  website?: T
-  phone?: T
-  logo?: T
-  approved?: T
-  updatedAt?: T
-  createdAt?: T
-  email?: T
-  resetPasswordToken?: T
-  resetPasswordExpiration?: T
-  salt?: T
-  hash?: T
-  loginAttempts?: T
-  lockUntil?: T
+        street?: T;
+        number?: T;
+        postalCode?: T;
+        city?: T;
+      };
+  website?: T;
+  phone?: T;
+  logo?: T;
+  approved?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  email?: T;
+  resetPasswordToken?: T;
+  resetPasswordExpiration?: T;
+  salt?: T;
+  hash?: T;
+  loginAttempts?: T;
+  lockUntil?: T;
   sessions?:
     | T
     | {
-        id?: T
-        createdAt?: T
-        expiresAt?: T
-      }
+        id?: T;
+        createdAt?: T;
+        expiresAt?: T;
+      };
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "events_select".
  */
 export interface EventsSelect<T extends boolean = true> {
-  title?: T
-  subtitle?: T
-  eventType?: T
-  startDate?: T
-  endDate?: T
+  title?: T;
+  subtitle?: T;
+  eventType?: T;
+  startDate?: T;
+  endDate?: T;
   time?:
     | T
     | {
-        from?: T
-        to?: T
-      }
-  description?: T
-  image?: T
-  location?: T
-  organizer?: T
-  isAccessible?: T
+        from?: T;
+        to?: T;
+      };
+  description?: T;
+  image?: T;
+  location?: T;
+  organizer?: T;
+  isAccessible?: T;
   cost?:
     | T
     | {
-        isFree?: T
-        details?: T
-      }
+        isFree?: T;
+        details?: T;
+      };
   registration?:
     | T
     | {
-        required?: T
-        details?: T
-      }
-  tags?: T
-  status?: T
-  updatedAt?: T
-  createdAt?: T
+        required?: T;
+        details?: T;
+      };
+  tags?: T;
+  status?: T;
+  expiryDate?: T;
+  lastRenewalReminder?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "locations_select".
  */
 export interface LocationsSelect<T extends boolean = true> {
-  name?: T
-  shortName?: T
-  description?: T
-  image?: T
+  name?: T;
+  shortName?: T;
+  description?: T;
+  image?: T;
   address?:
     | T
     | {
-        street?: T
-        number?: T
-        postalCode?: T
-        city?: T
-      }
-  coordinates?: T
+        street?: T;
+        number?: T;
+        postalCode?: T;
+        city?: T;
+      };
+  coordinates?: T;
   mapPosition?:
     | T
     | {
-        x?: T
-        y?: T
-      }
-  openingHours?: T
-  updatedAt?: T
-  createdAt?: T
+        x?: T;
+        y?: T;
+      };
+  openingHours?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "tags_select".
  */
 export interface TagsSelect<T extends boolean = true> {
-  name?: T
-  slug?: T
-  category?: T
-  color?: T
-  updatedAt?: T
-  createdAt?: T
+  name?: T;
+  slug?: T;
+  category?: T;
+  color?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
-  alt?: T
-  updatedAt?: T
-  createdAt?: T
-  url?: T
-  thumbnailURL?: T
-  filename?: T
-  mimeType?: T
-  filesize?: T
-  width?: T
-  height?: T
-  focalX?: T
-  focalY?: T
+  alt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
   sizes?:
     | T
     | {
         thumbnail?:
           | T
           | {
-              url?: T
-              width?: T
-              height?: T
-              mimeType?: T
-              filesize?: T
-              filename?: T
-            }
+              url?: T;
+              width?: T;
+              height?: T;
+              mimeType?: T;
+              filesize?: T;
+              filename?: T;
+            };
         card?:
           | T
           | {
-              url?: T
-              width?: T
-              height?: T
-              mimeType?: T
-              filesize?: T
-              filename?: T
-            }
+              url?: T;
+              width?: T;
+              height?: T;
+              mimeType?: T;
+              filesize?: T;
+              filename?: T;
+            };
         tablet?:
           | T
           | {
-              url?: T
-              width?: T
-              height?: T
-              mimeType?: T
-              filesize?: T
-              filename?: T
-            }
-      }
+              url?: T;
+              width?: T;
+              height?: T;
+              mimeType?: T;
+              filesize?: T;
+              filename?: T;
+            };
+      };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "notes_select".
+ */
+export interface NotesSelect<T extends boolean = true> {
+  content?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents_select".
  */
 export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
-  document?: T
-  globalSlug?: T
-  user?: T
-  updatedAt?: T
-  createdAt?: T
+  document?: T;
+  globalSlug?: T;
+  user?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-preferences_select".
  */
 export interface PayloadPreferencesSelect<T extends boolean = true> {
-  user?: T
-  key?: T
-  value?: T
-  updatedAt?: T
-  createdAt?: T
+  user?: T;
+  key?: T;
+  value?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-migrations_select".
  */
 export interface PayloadMigrationsSelect<T extends boolean = true> {
-  name?: T
-  batch?: T
-  updatedAt?: T
-  createdAt?: T
+  name?: T;
+  batch?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {
-  [k: string]: unknown
+  [k: string]: unknown;
 }
+
 
 declare module 'payload' {
   export interface GeneratedTypes extends Config {}

--- a/backend/src/payload.config.ts
+++ b/backend/src/payload.config.ts
@@ -6,6 +6,8 @@ import Events from './collections/Events'
 import Locations from './collections/Locations'
 import Tags from './collections/Tags'
 import Media from './collections/Media'
+import { Users } from './collections/Users'
+import Notes from './collections/Notes'
 import 'dotenv/config' // make sure env vars are available
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
 
@@ -18,12 +20,12 @@ export default buildConfig({
   }),
   serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL || 'http://localhost:3000',
   admin: {
-    user: Organizations.slug,
+    user: Users.slug,
     meta: {
       titleSuffix: '- MoaFinder CMS',
     },
   },
-  collections: [Organizations, Events, Locations, Tags, Media],
+  collections: [Users, Organizations, Events, Locations, Tags, Media, Notes],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import EventDetail from './pages/EventDetail';
 import PlaceProfile from './pages/PlaceProfile';
+import NotesPage from './pages/NotesPage';
 import './App.css';
 
 function App() {
@@ -26,6 +27,7 @@ function App() {
           <Route path="/kontakt" element={<ContactPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/notes" element={<NotesPage />} />
         </Routes>
       </main>
       <Footer />

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import SearchOverlay from './SearchOverlay';
@@ -8,6 +9,7 @@ import pigeonWhite from '../assets/pigeon_white.png';
 const Header = () => {
   const [showSearch, setShowSearch] = useState(false);
   const location = useLocation();
+  const { user, logout } = useAuth();
   
   const isActive = (path) => {
     return location.pathname === path ? 'text-green-400' : 'text-white hover:text-green-400';
@@ -51,9 +53,23 @@ const Header = () => {
               >
                 <FontAwesomeIcon icon={faSearch} className="w-5 h-5" />
               </button>
-              <Link to="/login" className="font-medium text-white hover:text-green-400 transition-colors">
-                Login
-              </Link>
+              {user ? (
+                <>
+                  <Link to="/notes" className="font-medium text-white hover:text-green-400 transition-colors">
+                    Notes
+                  </Link>
+                  <button
+                    onClick={logout}
+                    className="font-medium text-white hover:text-green-400 transition-colors"
+                  >
+                    Logout
+                  </button>
+                </>
+              ) : (
+                <Link to="/login" className="font-medium text-white hover:text-green-400 transition-colors">
+                  Login
+                </Link>
+              )}
             </div>
           </div>
           

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const AuthContext = createContext(null)
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user')
+    if (stored) {
+      setUser(JSON.parse(stored))
+    }
+  }, [])
+
+  const login = async (email, password) => {
+    const res = await fetch('http://localhost:3000/api/users/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+      credentials: 'include',
+    })
+
+    if (!res.ok) {
+      throw new Error('Login failed')
+    }
+
+    const data = await res.json()
+    setUser(data.user)
+    localStorage.setItem('user', JSON.stringify(data.user))
+  }
+
+  const logout = async () => {
+    await fetch('http://localhost:3000/api/users/logout', {
+      method: 'POST',
+      credentials: 'include',
+    })
+    setUser(null)
+    localStorage.removeItem('user')
+  }
+
+  return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './App.css';
+import { AuthProvider } from './context/AuthContext';
 
 // Entry point for the React application. Wraps the App component in
 // BrowserRouter to enable client-side routing. The CSS import must
@@ -12,8 +13,10 @@ import './App.css';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import kiezMachenLogo from '../assets/kiezmachen_logo.png';
 import refoLogo from '../assets/refo_logo.png';
 import partnerLogos from '../assets/partner_logos.png';
+import { useAuth } from '../context/AuthContext';
 
 /**
  * Login page matching the Figma design.
@@ -15,27 +16,27 @@ import partnerLogos from '../assets/partner_logos.png';
  */
 const LoginPage = () => {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [showPassword, setShowPassword] = useState(false);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
-    
+
     if (!email || !password) {
       setError('Bitte geben Sie Ihre Zugangsdaten ein.');
       return;
     }
-    
-    // TODO: Replace with real authentication
-    console.log('Login attempt:', { email, password });
-    
-    // Simulate successful login
-    localStorage.setItem('isLoggedIn', 'true');
-    localStorage.setItem('userEmail', email);
-    navigate('/');
+
+    try {
+      await login(email, password);
+      navigate('/notes');
+    } catch (err) {
+      setError('Login fehlgeschlagen');
+    }
   };
 
   return (

--- a/frontend/src/pages/NotesPage.jsx
+++ b/frontend/src/pages/NotesPage.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
+
+const NotesPage = () => {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [content, setContent] = useState('')
+  const [message, setMessage] = useState('')
+
+  if (!user) {
+    navigate('/login')
+    return null
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const res = await fetch('http://localhost:3000/api/notes', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+      credentials: 'include',
+    })
+    if (res.ok) {
+      setMessage('Note saved!')
+      setContent('')
+    } else {
+      setMessage('Failed to save')
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Create Note</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="w-full border p-2"
+          required
+        />
+        <button type="submit" className="bg-[#7CB92C] text-white px-4 py-2 rounded">
+          Save
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  )
+}
+
+export default NotesPage


### PR DESCRIPTION
## Summary
- add role field to users and register auth collection in Payload config
- introduce notes collection for logged-in user content
- implement frontend auth context, login page integration, and note creation page

## Testing
- `pnpm run generate:types`
- `DATABASE_URI=mongodb://localhost:27017/test PAYLOAD_SECRET=test pnpm test` *(fails: Hook timed out in 10000ms)*
- `pnpm lint`
- `pnpm --dir frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b711310b688326a26694ce869530a9