### PR TITLE
Add event recurrence and basic CRUD UI

### DIFF
--- a/backend/src/collections/Events.ts
+++ b/backend/src/collections/Events.ts
@@ -87,6 +87,41 @@ const Events: CollectionConfig = {
       },
     },
     {
+      name: 'recurrence',
+      type: 'group',
+      label: 'Wiederholung',
+      admin: {
+        condition: (_, siblingData) => siblingData?.eventType !== 'einmalig',
+      },
+      fields: [
+        {
+          name: 'daysOfWeek',
+          type: 'select',
+          hasMany: true,
+          label: 'Wochentage',
+          options: [
+            { label: 'Montag', value: 'mon' },
+            { label: 'Dienstag', value: 'tue' },
+            { label: 'Mittwoch', value: 'wed' },
+            { label: 'Donnerstag', value: 'thu' },
+            { label: 'Freitag', value: 'fri' },
+            { label: 'Samstag', value: 'sat' },
+            { label: 'Sonntag', value: 'sun' },
+          ],
+        },
+        {
+          name: 'repeatUntil',
+          type: 'date',
+          label: 'Wiederholen bis',
+          admin: {
+            date: {
+              pickerAppearance: 'day',
+            },
+          },
+        },
+      ],
+    },
+    {
       name: 'time',
       type: 'group',
       label: 'Uhrzeit',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,9 @@ import RegisterPage from './pages/RegisterPage';
 import EventDetail from './pages/EventDetail';
 import PlaceProfile from './pages/PlaceProfile';
 import NotesPage from './pages/NotesPage';
+import EventsList from './pages/EventsList';
+import EventCreate from './pages/EventCreate';
+import EventEdit from './pages/EventEdit';
 import './App.css';
 
 function App() {
@@ -28,6 +31,9 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/notes" element={<NotesPage />} />
+          <Route path="/events" element={<EventsList />} />
+          <Route path="/events/new" element={<EventCreate />} />
+          <Route path="/events/:id/edit" element={<EventEdit />} />
         </Routes>
       </main>
       <Footer />

--- a/frontend/src/api/events.js
+++ b/frontend/src/api/events.js
@@ -1,0 +1,44 @@
+const API_URL = '/api/events';
+
+export async function listEvents() {
+  const res = await fetch(API_URL, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to fetch events');
+  return res.json();
+}
+
+export async function getEvent(id) {
+  const res = await fetch(`${API_URL}/${id}`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to fetch event');
+  return res.json();
+}
+
+export async function createEvent(data) {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create event');
+  return res.json();
+}
+
+export async function updateEvent(id, data) {
+  const res = await fetch(`${API_URL}/${id}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update event');
+  return res.json();
+}
+
+export async function deleteEvent(id) {
+  const res = await fetch(`${API_URL}/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to delete event');
+  return res.json();
+}

--- a/frontend/src/components/EventForm.jsx
+++ b/frontend/src/components/EventForm.jsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+
+const dayOptions = [
+  { label: 'Montag', value: 'mon' },
+  { label: 'Dienstag', value: 'tue' },
+  { label: 'Mittwoch', value: 'wed' },
+  { label: 'Donnerstag', value: 'thu' },
+  { label: 'Freitag', value: 'fri' },
+  { label: 'Samstag', value: 'sat' },
+  { label: 'Sonntag', value: 'sun' },
+];
+
+export default function EventForm({ initialData = {}, onSubmit }) {
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    eventType: 'einmalig',
+    startDate: '',
+    endDate: '',
+    recurrence: { daysOfWeek: [], repeatUntil: '' },
+    ...initialData,
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleRecurrenceChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      recurrence: { ...prev.recurrence, [name]: value },
+    }));
+  };
+
+  const handleDaysChange = (e) => {
+    const values = Array.from(e.target.selectedOptions).map((o) => o.value);
+    setForm((prev) => ({
+      ...prev,
+      recurrence: { ...prev.recurrence, daysOfWeek: values },
+    }));
+  };
+
+  const submit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Titel</label>
+        <input
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+          className="border p-2 w-full"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1">Beschreibung</label>
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          className="border p-2 w-full"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1">Art der Veranstaltung</label>
+        <select
+          name="eventType"
+          value={form.eventType}
+          onChange={handleChange}
+          className="border p-2 w-full"
+        >
+          <option value="einmalig">Einmalig</option>
+          <option value="täglich">Täglich</option>
+          <option value="wöchentlich">Wöchentlich</option>
+          <option value="monatlich">Monatlich</option>
+          <option value="jährlich">Jährlich</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="block mb-1">Startdatum</label>
+        <input
+          type="datetime-local"
+          name="startDate"
+          value={form.startDate}
+          onChange={handleChange}
+          className="border p-2 w-full"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1">Enddatum</label>
+        <input
+          type="datetime-local"
+          name="endDate"
+          value={form.endDate || ''}
+          onChange={handleChange}
+          className="border p-2 w-full"
+        />
+      </div>
+
+      {form.eventType !== 'einmalig' && (
+        <div className="space-y-2 border p-2">
+          <p className="font-semibold">Wiederholung</p>
+
+          <div>
+            <label className="block mb-1">Wochentage</label>
+            <select
+              multiple
+              name="daysOfWeek"
+              value={form.recurrence.daysOfWeek}
+              onChange={handleDaysChange}
+              className="border p-2 w-full"
+            >
+              {dayOptions.map((d) => (
+                <option key={d.value} value={d.value}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block mb-1">Wiederholen bis</label>
+            <input
+              type="date"
+              name="repeatUntil"
+              value={form.recurrence.repeatUntil || ''}
+              onChange={handleRecurrenceChange}
+              className="border p-2 w-full"
+            />
+          </div>
+        </div>
+      )}
+
+      <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">
+        Speichern
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/EventCreate.jsx
+++ b/frontend/src/pages/EventCreate.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import EventForm from '../components/EventForm';
+import { createEvent } from '../api/events';
+
+export default function EventCreate() {
+  const navigate = useNavigate();
+
+  const handleSubmit = async (data) => {
+    await createEvent(data);
+    navigate('/events');
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl mb-4">Event erstellen</h1>
+      <EventForm onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/frontend/src/pages/EventEdit.jsx
+++ b/frontend/src/pages/EventEdit.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import EventForm from '../components/EventForm';
+import { getEvent, updateEvent } from '../api/events';
+
+export default function EventEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [event, setEvent] = useState(null);
+
+  useEffect(() => {
+    getEvent(id).then(setEvent);
+  }, [id]);
+
+  const handleSubmit = async (data) => {
+    await updateEvent(id, data);
+    navigate('/events');
+  };
+
+  if (!event) return <p className="p-4">Laden...</p>;
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl mb-4">Event bearbeiten</h1>
+      <EventForm initialData={event} onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/frontend/src/pages/EventsList.jsx
+++ b/frontend/src/pages/EventsList.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { listEvents, deleteEvent } from '../api/events';
+
+export default function EventsList() {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    listEvents().then(setEvents).catch(console.error);
+  }, []);
+
+  const remove = async (id) => {
+    await deleteEvent(id);
+    setEvents((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <Link to="/events/new" className="bg-green-600 text-white px-4 py-2 rounded">
+        Neues Event
+      </Link>
+      <ul className="mt-4 space-y-2">
+        {events.map((ev) => (
+          <li key={ev.id} className="border p-2 flex justify-between">
+            <Link to={`/events/${ev.id}/edit`} className="text-green-700">
+              {ev.title}
+            </Link>
+            <button onClick={() => remove(ev.id)} className="text-red-600">
+              Löschen
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add recurrence group to `events` collection
- provide React event API helper and form
- introduce pages for listing, creating, and editing events with routing

## Testing
- `npm test` (backend) *(fails: missing secret key)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b99f7659ac83268fd6e012c91985d1