### PR TITLE
chore: enable modern module resolution for eslint

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,3 +1,6 @@
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+require('@rushstack/eslint-patch/modern-module-resolution')
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { FlatCompat } from '@eslint/eslintrc'


### PR DESCRIPTION
## Summary
- load `@rushstack/eslint-patch` to modernize module resolution in backend ESLint config

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80f4289e083268edeb1925bf59b8c