### PR TITLE
fix(date-picker): use valid pickerAppearance options

### DIFF
--- a/backend/src/collections/Events.ts
+++ b/backend/src/collections/Events.ts
@@ -115,7 +115,7 @@ const Events: CollectionConfig = {
           label: 'Wiederholen bis',
           admin: {
             date: {
-              pickerAppearance: 'day',
+              pickerAppearance: 'dayOnly',
             },
           },
         },
@@ -215,7 +215,7 @@ const Events: CollectionConfig = {
       label: 'Ablaufdatum',
       admin: {
         date: {
-          pickerAppearance: 'day',
+          pickerAppearance: 'dayOnly',
         },
       },
     },
@@ -230,7 +230,7 @@ const Events: CollectionConfig = {
   ],
   hooks: {
     beforeValidate: [
-      ({ data }: { data: any }) => {
+      ({ data }: { data?: any }) => {
         if (!data?.expiryDate) {
           const baseDate = data?.endDate || data?.startDate
           if (baseDate) {


### PR DESCRIPTION
## Summary
- use `dayOnly` picker for repeatUntil and expiryDate date fields
- accept optional `data` in Events beforeValidate hook

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c80f33b038832683501f6d1076dc0a