### PR TITLE
chore: revert pnpm overhaul and keep docker fix minimal

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,9 +48,6 @@ ENV NODE_ENV production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-# Remove this line if you do not have this folder
-COPY --from=builder /app/public ./public
-
 # Set the correct permission for prerender cache
 RUN mkdir .next
 RUN chown nextjs:nodejs .next


### PR DESCRIPTION
## Summary
- restore the backend Dockerfile to its original multi-package-manager flow while leaving out the `/app/public` copy that broke builds
- drop the pnpm-specific dependency changes by reinstating the original `package.json` and `package-lock.json`
- roll back the ESLint, event hooks, and frontend form rewrites so the codebase only contains the minimal changes needed for the build fix

## Testing
- `npm --prefix backend ci`
- `CI=1 npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7e9ea51048326aa9b41a56116d80f