### PR TITLE
Add health check route for App Runner

### DIFF
--- a/backend/src/app/api/health/route.ts
+++ b/backend/src/app/api/health/route.ts
@@ -1,0 +1,4 @@
+import { NextResponse } from 'next/server'
+
+export const GET = () =>
+  NextResponse.json({ status: 'ok' })


### PR DESCRIPTION
## Summary
- add a dedicated `/api/health` route that responds with HTTP 200 for App Runner health checks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c977d9a3148326ad99703f2c6d798d