### PR TITLE
Centralize frontend API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ EVENT_APPROVAL_NOTIFICATION_EMAILS=team@moafinder.de
 
 `DATABASE_URI` should point to the MongoDB instance you want to use. Any operations run against the backend will write directly to this database, so consider using a test database for local development.
 
+For the frontend, create a `frontend/.env` file or configure the variable in your hosting provider:
+
+```
+VITE_API_BASE_URL=<https://your-api-domain>
+```
+
+When running the Vite dev server without a dedicated backend domain you can leave this empty (`VITE_API_BASE_URL=`) so requests continue to target the relative `/api/...` paths proxied by the development server.
+
 ## Local Development
 1. **Install dependencies**
    ```
@@ -70,7 +78,7 @@ pnpm lint
 ### 1. Frontend (AWS Amplify)
 The Amplify app is already connected to your repository and available at <https://main.d1i5ilm5fqb0i9.amplifyapp.com/>.
 
-1. In the Amplify console open **App settings → Environment variables** and provide any frontend variables you need (for example `VITE_API_BASE_URL` if you introduce one later).
+1. In the Amplify console open **App settings → Environment variables** and set `VITE_API_BASE_URL` to the App Runner domain (for example `https://trcfif3bvg.eu-central-1.awsapprunner.com`).
 2. Add a rewrite so the static site can talk to the backend: **App settings → Rewrites and redirects** → add
 
    | Source | Target | Type |

--- a/amplify.yml
+++ b/amplify.yml
@@ -16,3 +16,6 @@ applications:
       cache:
         paths:
           - node_modules/**/*
+      environment:
+        variables:
+          VITE_API_BASE_URL: https://trcfif3bvg.eu-central-1.awsapprunner.com

--- a/frontend/src/api/baseUrl.js
+++ b/frontend/src/api/baseUrl.js
@@ -1,0 +1,18 @@
+const rawBaseUrl = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE_URL) || ''
+const normalizedBaseUrl = typeof rawBaseUrl === 'string' ? rawBaseUrl.replace(/\/+$/, '') : ''
+
+export const apiBaseUrl = normalizedBaseUrl
+
+export function buildApiUrl(path = '') {
+  if (typeof path !== 'string') {
+    throw new TypeError('path must be a string')
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+
+  if (!normalizedBaseUrl) {
+    return normalizedPath
+  }
+
+  return `${normalizedBaseUrl}${normalizedPath}`
+}

--- a/frontend/src/api/events.js
+++ b/frontend/src/api/events.js
@@ -1,19 +1,21 @@
+import { buildApiUrl } from './baseUrl';
+
 const API_URL = '/api/events';
 
 export async function listEvents() {
-  const res = await fetch(API_URL, { credentials: 'include' });
+  const res = await fetch(buildApiUrl(API_URL), { credentials: 'include' });
   if (!res.ok) throw new Error('Failed to fetch events');
   return res.json();
 }
 
 export async function getEvent(id) {
-  const res = await fetch(`${API_URL}/${id}`, { credentials: 'include' });
+  const res = await fetch(buildApiUrl(`${API_URL}/${id}`), { credentials: 'include' });
   if (!res.ok) throw new Error('Failed to fetch event');
   return res.json();
 }
 
 export async function createEvent(data) {
-  const res = await fetch(API_URL, {
+  const res = await fetch(buildApiUrl(API_URL), {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -24,7 +26,7 @@ export async function createEvent(data) {
 }
 
 export async function updateEvent(id, data) {
-  const res = await fetch(`${API_URL}/${id}`, {
+  const res = await fetch(buildApiUrl(`${API_URL}/${id}`), {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -35,7 +37,7 @@ export async function updateEvent(id, data) {
 }
 
 export async function deleteEvent(id) {
-  const res = await fetch(`${API_URL}/${id}`, {
+  const res = await fetch(buildApiUrl(`${API_URL}/${id}`), {
     method: 'DELETE',
     credentials: 'include',
   });

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { buildApiUrl } from '../api/baseUrl'
 
 const AuthContext = createContext(null)
 
@@ -13,7 +14,7 @@ export const AuthProvider = ({ children }) => {
   }, [])
 
   const login = async (email, password) => {
-    const res = await fetch('/api/users/login', {
+    const res = await fetch(buildApiUrl('/api/users/login'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -32,7 +33,7 @@ export const AuthProvider = ({ children }) => {
   }
 
   const logout = async () => {
-    await fetch('/api/users/logout', {
+    await fetch(buildApiUrl('/api/users/logout'), {
       method: 'POST',
       credentials: 'include',
     })

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { buildApiUrl } from '../api/baseUrl';
 
 /**
  * Contact page with address and a contact form. The form currently
@@ -26,7 +27,7 @@ const ContactPage = () => {
     }
     try {
       setIsSubmitting(true);
-      const response = await fetch('/api/contact', {
+      const response = await fetch(buildApiUrl('/api/contact'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/NotesPage.jsx
+++ b/frontend/src/pages/NotesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { buildApiUrl } from '../api/baseUrl'
 
 const NotesPage = () => {
   const { user } = useAuth()
@@ -15,7 +16,7 @@ const NotesPage = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const res = await fetch('http://localhost:3000/api/notes', {
+    const res = await fetch(buildApiUrl('/api/notes'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { buildApiUrl } from '../api/baseUrl';
 
 /**
  * Registration page. Collects user information for account creation
@@ -42,7 +43,7 @@ const RegisterPage = () => {
     }
     try {
       setIsSubmitting(true);
-      const response = await fetch('/api/users/register', {
+      const response = await fetch(buildApiUrl('/api/users/register'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add a shared helper that normalizes `VITE_API_BASE_URL` and provides a `buildApiUrl` utility
- update frontend fetch calls to use the new helper instead of hard-coded API URLs
- document the new environment variable and configure Amplify to export it during builds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b1cd0288326952953127d5fc28c