### PR TITLE
Adjust frontend base URL env access

### DIFF
--- a/frontend/src/api/baseUrl.js
+++ b/frontend/src/api/baseUrl.js
@@ -1,4 +1,5 @@
-const rawBaseUrl = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE_URL) || ''
+const rawBaseUrl = typeof import.meta !== 'undefined' ? import.meta.env.VITE_API_BASE_URL ?? '' : ''
+const importMetaMode = typeof import.meta !== 'undefined' ? import.meta.env.MODE ?? '' : ''
 
 let sanitizedBaseUrl = ''
 
@@ -26,9 +27,7 @@ if (
   window.location &&
   window.location.origin &&
   sanitizedBaseUrl === '' &&
-  typeof import.meta !== 'undefined' &&
-  import.meta.env &&
-  import.meta.env.MODE === 'production'
+  importMetaMode === 'production'
 ) {
   console.warn(
     'VITE_API_BASE_URL is empty; frontend requests will target the current origin. Ensure Amplify exports VITE_API_BASE_URL so API calls reach App Runner.'


### PR DESCRIPTION
## Summary
- update the API base URL detection to rely on import.meta.env while keeping empty fallback
- reuse the same import.meta.env pattern when warning about missing production configuration

## Testing
- VITE_API_BASE_URL=https://trcfif3bvg.eu-central-1.awsapprunner.com/api npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd4cd8875c83268ecaa9513d59c6ad