### PR TITLE
Allow unauthenticated user creation in Payload

### DIFF
--- a/backend/src/collections/Users.ts
+++ b/backend/src/collections/Users.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
   slug: 'users',
+  access: {
+    create: () => true,
+  },
   admin: {
     useAsTitle: 'email',
   },


### PR DESCRIPTION
## Summary
- allow the users collection to be created without an existing session by configuring create access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5060f5448326b76ed44148163513