### PR TITLE
Allow public user creation while locking updates to admins

### DIFF
--- a/backend/src/collections/Users.ts
+++ b/backend/src/collections/Users.ts
@@ -4,6 +4,7 @@ export const Users: CollectionConfig = {
   slug: 'users',
   access: {
     create: () => true,
+    update: ({ req }) => req.user?.role === 'admin',
   },
   admin: {
     useAsTitle: 'email',


### PR DESCRIPTION
## Summary
- allow user documents to be created without authentication while restricting updates to admins

## Testing
- not run (environment only changes configuration)

------
https://chatgpt.com/codex/tasks/task_e_68dd6372014083268833702f26bea679