### PR TITLE
Fix CORS configuration for registration endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,14 @@ To do so, follow these steps:
 
 The Payload config is tailored specifically to the needs of most websites. It is pre-configured in the following ways:
 
+### CORS configuration
+
+Cross-origin requests from the hosted frontends (Amplify and local development) are allowed out of the box. The list of trusted
+origins is derived from the following environment variables—`FRONTEND_URL`, `NEXT_PUBLIC_SITE_URL`, `PAYLOAD_PUBLIC_SITE_URL`,
+`PAYLOAD_PUBLIC_SERVER_URL`, and `CORS_ORIGINS`—with sensible defaults for the production Amplify domain and common local ports.
+If you expose the API to additional domains, append them to `CORS_ORIGINS` as a comma-separated list so that the registration
+endpoint continues to respond to browser preflight checks.
+
 ### Collections
 
 See the [Collections](https://payloadcms.com/docs/configuration/collections) docs for details on how to extend this functionality.

--- a/backend/src/payload.config.ts
+++ b/backend/src/payload.config.ts
@@ -13,6 +13,40 @@ import { mongooseAdapter } from '@payloadcms/db-mongodb'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+const parseOrigins = (value?: string | null) =>
+  value
+    ?.split(',')
+    .map((origin) => origin.trim().replace(/\/$/, ''))
+    .filter(Boolean) ?? []
+
+const defaultCorsOrigins = [
+  process.env.FRONTEND_URL,
+  process.env.NEXT_PUBLIC_SITE_URL,
+  process.env.PAYLOAD_PUBLIC_SITE_URL,
+  process.env.PAYLOAD_PUBLIC_SERVER_URL,
+  // Production frontend hosted on Amplify.
+  'https://main.d1i5ilm5fqb0i9.amplifyapp.com',
+  // Local development ports for Next.js and Vite frontends.
+  'http://localhost:3000',
+  'http://localhost:5173',
+]
+  .filter(Boolean)
+  .map((origin) => origin.replace(/\/$/, ''))
+
+const corsOrigins = Array.from(
+  new Set([
+    ...defaultCorsOrigins,
+    ...parseOrigins(process.env.CORS_ORIGINS),
+  ]),
+)
+
+const corsConfig = {
+  origin: corsOrigins,
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+}
+
 export default buildConfig({
   secret: process.env.PAYLOAD_SECRET as string,
   db: mongooseAdapter({
@@ -29,6 +63,6 @@ export default buildConfig({
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },
-  cors: process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [],
-  csrf: process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [],
+  cors: corsConfig,
+  csrf: corsOrigins,
 })


### PR DESCRIPTION
## Summary
- derive CORS/CSRF origins from environment variables with sane defaults for Amplify and local development
- enable credentialed cross-origin requests by configuring allowed methods and headers for the Payload API
- document the new CORS behaviour and how to extend the allow list in the backend README

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd68a26c6083269d64ea5f779be9df